### PR TITLE
New LDAP attributes in accordance with Scolaris

### DIFF
--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -408,6 +408,15 @@ attributeTypes: (
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
       SINGLE-VALUE )
 #
+# Name:     base4kidsLegalGuardianOf
+# Syntax:   DN
+# Examples: "uid=S12345,ou=People,dc=example,dc=com"
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.33
+      NAME 'base4kidsLegalGuardianOf'
+      DESC 'References to DNs for which this person is a legal guardian'
+      SUP member )
+#
 #
 ###############################################################################
 # Object Classes
@@ -446,6 +455,7 @@ objectClasses: ( 1.3.6.1.4.1.31534.2.5.1.1
             base4kidsImapIsActive $
             base4kidsIsActive $
             base4kidsLearningPlatformIsActive $
+            base4kidsLegalGuardianOf $
             base4kidsNextcloudUserQuota $
             base4kidsPersiskaNumber $
             base4kidsRole $

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -426,6 +426,19 @@ attributeTypes: (
       DESC 'References to legal guardian DNs for this person'
       SUP base4kidsLegalGuardianOf )
 #
+# Name:     base4kidsSchoolLevel
+# Syntax:   Printable String
+# Examples: "KINDERGARTEN" "BASISSTUFE" "PRIMARSTUFE" "SEKUNDARSTUFE1" "SONDERSCHULKLASSE"
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.34
+      NAME 'base4kidsSchoolLevel'
+      DESC 'The school level'
+      EQUALITY caseIgnoreMatch
+      ORDERING caseIgnoreOrderingMatch
+      SUBSTR caseIgnoreSubstringsMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
+      SINGLE-VALUE )
+#
 #
 ###############################################################################
 # Object Classes
@@ -500,6 +513,7 @@ objectClasses: (
             base4kidsSchoolClassSubGroup $
             base4kidsSchoolClassYear $
             base4kidsSchoolDistrict $
+            base4kidsSchoolLevel $
             base4kidsSchoolLocation $
             base4kidsSmtpReceiveIsActive $
             base4kidsSmtpSubmissionIsActive ) )

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -362,6 +362,19 @@ attributeTypes: (
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
       SINGLE-VALUE )
 #
+# Name:     base4kidsPersiskaNumber
+# Syntax:   Printable String
+# Examples: 123.456
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.29
+      NAME 'base4kidsPersiskaNumber'
+      DESC 'Employees reference number from the information system PERSISKA'
+      EQUALITY caseExactMatch
+      ORDERING caseExactOrderingMatch
+      SUBSTR caseExactSubstringsMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
+      SINGLE-VALUE )
+#
 #
 ###############################################################################
 # Object Classes
@@ -401,6 +414,7 @@ objectClasses: ( 1.3.6.1.4.1.31534.2.5.1.1
             base4kidsIsActive $
             base4kidsLearningPlatformIsActive $
             base4kidsNextcloudUserQuota $
+            base4kidsPersiskaNumber $
             base4kidsRole $
             base4kidsSmtpReceiveIsActive $
             base4kidsSmtpSubmissionIsActive $

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -387,6 +387,15 @@ attributeTypes: (
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
       SINGLE-VALUE )
 #
+# Name:     base4kidsSchoolClassYear
+# Syntax:   Directory String
+# Examples: "2018/2019"
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.31
+      NAME 'base4kidsSchoolClassYear'
+      DESC 'The school class year'
+      SUP base4kidsSchoolClassName )
+#
 #
 ###############################################################################
 # Object Classes
@@ -456,6 +465,7 @@ objectClasses: (
             base4kidsSchoolClassLevel $
             base4kidsSchoolClassName $
             base4kidsSchoolClassSubGroup $
+            base4kidsSchoolClassYear $
             base4kidsSchoolDistrict $
             base4kidsSchoolLocation $
             base4kidsSmtpReceiveIsActive $

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -375,6 +375,18 @@ attributeTypes: (
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
       SINGLE-VALUE )
 #
+# Name:     base4kidsExpirationDate
+# Syntax:   Generalized Time
+# Examples: 20191221235859Z
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.30
+      NAME 'base4kidsExpirationDate'
+      DESC 'Expiration date of a Base4Kids object in coordinated universal time'
+      EQUALITY generalizedTimeMatch
+      ORDERING generalizedTimeOrderingMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+      SINGLE-VALUE )
+#
 #
 ###############################################################################
 # Object Classes
@@ -430,6 +442,7 @@ objectClasses: (
       SUP top AUXILIARY
       MAY (
             base4kidsEgovId $
+            base4kidsExpirationDate $
             base4kidsGroupType $
             base4kidsIsActive $
             base4kidsMaharaGroupId $

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -439,6 +439,18 @@ attributeTypes: (
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
       SINGLE-VALUE )
 #
+# Name:     base4kidsSchoolCycle
+# Syntax:   Integer
+# Examples: 0 - 3
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.35
+      NAME 'base4kidsSchoolCycle'
+      DESC 'The school cycle'
+      EQUALITY integerMatch
+      ORDERING integerOrderingMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+#
 #
 ###############################################################################
 # Object Classes
@@ -512,6 +524,7 @@ objectClasses: (
             base4kidsSchoolClassName $
             base4kidsSchoolClassSubGroup $
             base4kidsSchoolClassYear $
+            base4kidsSchoolCycle $
             base4kidsSchoolDistrict $
             base4kidsSchoolLevel $
             base4kidsSchoolLocation $

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -2,9 +2,9 @@
 # Base4Kids LDAP schema
 ################################################################################
 #
-# Copyright (C) 2018 Adfinis SyGroup AG
-#                    https://adfinis-sygroup.ch
-#                    info@adfinis-sygroup.ch
+# Copyright (C) 2018 - 2019  Adfinis SyGroup AG
+#                            https://adfinis-sygroup.ch
+#                            info@adfinis-sygroup.ch
 #
 # This schema is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public 

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -417,6 +417,15 @@ attributeTypes: (
       DESC 'References to DNs for which this person is a legal guardian'
       SUP member )
 #
+# Name:     base4kidsLegalGuardian
+# Syntax:   DN
+# Examples: "uid=E6789,ou=People,dc=example,dc=com"
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.33
+      NAME 'base4kidsLegalGuardian'
+      DESC 'References to legal guardian DNs for this person'
+      SUP base4kidsLegalGuardianOf )
+#
 #
 ###############################################################################
 # Object Classes
@@ -455,6 +464,7 @@ objectClasses: ( 1.3.6.1.4.1.31534.2.5.1.1
             base4kidsImapIsActive $
             base4kidsIsActive $
             base4kidsLearningPlatformIsActive $
+            base4kidsLegalGuardian $
             base4kidsLegalGuardianOf $
             base4kidsNextcloudUserQuota $
             base4kidsPersiskaNumber $

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -349,6 +349,19 @@ attributeTypes: (
       DESC 'Nextcloud school class template folder share ID'
       SUP base4kidsNextcloudShareId )
 #
+# Name:     base4kidsGender
+# Syntax:   Printable String
+# Examples: 'm' (male), 'f' (female), 'o' (other)
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.28
+      NAME 'base4kidsGender'
+      DESC 'Gender of a person'
+      EQUALITY caseExactMatch
+      ORDERING caseExactOrderingMatch
+      SUBSTR caseExactSubstringsMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.44
+      SINGLE-VALUE )
+#
 #
 ###############################################################################
 # Object Classes
@@ -382,6 +395,7 @@ objectClasses: ( 1.3.6.1.4.1.31534.2.5.1.1
             base4kidsCloudStorageIsActive $
             base4kidsEgovId $
             base4kidsEportfolioIsActive $
+            base4kidsGender $
             base4kidsGroupwareIsActive $
             base4kidsImapIsActive $
             base4kidsIsActive $

--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -396,6 +396,18 @@ attributeTypes: (
       DESC 'The school class year'
       SUP base4kidsSchoolClassName )
 #
+# Name:     base4kidsSchoolProgrammYear
+# Syntax:   Integer
+# Examples: 1 - 9
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.32
+      NAME 'base4kidsSchoolProgrammYear'
+      DESC 'The school programm year (Programmjahr)'
+      EQUALITY integerMatch
+      ORDERING integerOrderingMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+      SINGLE-VALUE )
+#
 #
 ###############################################################################
 # Object Classes
@@ -437,6 +449,7 @@ objectClasses: ( 1.3.6.1.4.1.31534.2.5.1.1
             base4kidsNextcloudUserQuota $
             base4kidsPersiskaNumber $
             base4kidsRole $
+            base4kidsSchoolProgrammYear $
             base4kidsSmtpReceiveIsActive $
             base4kidsSmtpSubmissionIsActive $
             base4kidsWebmailIsActive ) )


### PR DESCRIPTION
The following PR adds additional LDAP attributes in accordance with Scolaris and customer requirements.

The following attributes were added:
* `base4kidsGender`: Gender of a person
* `base4kidsPersiskaNumber`: Employees reference number from the information system PERSISKA
* `base4kidsExpirationDate`: Expiration date of a Base4Kids object in coordinated universal time
* `base4kidsSchoolClassYear`: The school class year
* `base4kidsSchoolProgrammYear`: The school programm year (Programmjahr)
* `base4kidsLegalGuardianOf`: References to DNs for which a person is a legal guardian
* `base4kidsLegalGuardian`: References to legal guardian DNs of a person
* `base4kidsSchoolLevel`: Represents the level of a class
* `base4kidsSchoolCycle`: Defines to which cycle a given school class belongs to