### PR TITLE
Adding `base4kidsInitiator` attribute

### DIFF
--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -451,6 +451,15 @@ attributeTypes: (
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
       SINGLE-VALUE )
 #
+# Name:     base4kidsInitiator
+# Syntax:   DN
+# Examples: "uid=S12345,ou=People,dc=example,dc=com"
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.37
+      NAME 'base4kidsInitiator
+      DESC 'Reference to a DN of a person which created a specific resource'
+      SUP distinguishedName )
+#
 #
 ###############################################################################
 # Object Classes


### PR DESCRIPTION
The `base4kidsInitiator` attribute references a DN of a person which created a specific resource.

In a first step this will be used to reference the initiator of an ad-hoc workgroup.