### PR TITLE
Add base4kidsInitiator to base4kidsGroup object class

### DIFF
--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -520,6 +520,7 @@ objectClasses: (
             base4kidsEgovId $
             base4kidsExpirationDate $
             base4kidsGroupType $
+            base4kidsInitiator $
             base4kidsIsActive $
             base4kidsMaharaGroupId $
             base4kidsMattermostChannelId $


### PR DESCRIPTION
The `base4kidsInitiator` attribute was missing within the `base4kidsGroup` object class.