### PR TITLE
Adding base4kidsIsBlocked attribute

### DIFF
--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -469,6 +469,17 @@ attributeTypes: (
       DESC 'The school class supplement'
       SUP base4kidsSchoolClassName )
 #
+# Name:     base4kidsIsBlocked
+# Syntax:   Boolean
+# Examples, TRUE, FALSE
+attributeTypes: ( 
+      1.3.6.1.4.1.31534.2.5.2.39
+      NAME 'base4kidsIsBlocked'
+      DESC 'Determines whether a base4kids object is blocked'
+      EQUALITY booleanMatch
+      SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+      SINGLE-VALUE )
+#
 #
 ###############################################################################
 # Object Classes
@@ -506,6 +517,7 @@ objectClasses: ( 1.3.6.1.4.1.31534.2.5.1.1
             base4kidsGroupwareIsActive $
             base4kidsImapIsActive $
             base4kidsIsActive $
+            base4kidsIsBlocked $
             base4kidsLearningPlatformIsActive $
             base4kidsLegalGuardian $
             base4kidsLegalGuardianOf $
@@ -531,6 +543,7 @@ objectClasses: (
             base4kidsGroupType $
             base4kidsInitiator $
             base4kidsIsActive $
+            base4kidsIsBlocked $
             base4kidsMaharaGroupId $
             base4kidsMattermostChannelId $
             base4kidsMattermostTeamId $


### PR DESCRIPTION
This PR adds a new boolean `base4kidsIsBlocked` attribute which can be used to indicate whether a base4kids object is blocked or not.