### PR TITLE
Adding base4kidsCountryCode attribute.

### DIFF
--- a/base4kids2.ldif
+++ b/base4kids2.ldif
@@ -480,6 +480,15 @@ attributeTypes: (
       SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
       SINGLE-VALUE )
 #
+# Name:     base4kidsCountryCode
+# Syntax:   Country String
+# Examples, CH, DE, FR
+attributeTypes: (
+      1.3.6.1.4.1.31534.2.5.2.40
+      NAME 'base4kidsCountryCode'
+      DESC 'ISO 3166 two-letter country code'
+      SUP c )
+#
 #
 ###############################################################################
 # Object Classes
@@ -511,6 +520,7 @@ objectClasses: ( 1.3.6.1.4.1.31534.2.5.1.1
             base4kidsAppleId $ 
             base4kidsChatIsActive $
             base4kidsCloudStorageIsActive $
+            base4kidsCountryCode $
             base4kidsEgovId $
             base4kidsEportfolioIsActive $
             base4kidsGender $


### PR DESCRIPTION
The base4kidsCountryCode attribute contains a ISO 3166 two-letter country code, such as 'CH'.

It is derived from the existing 'c' ('countryName' in X.500) attribute [1] originating from the 'country' object class [2] (RFC 4519).

The 'country' object class is defined as 'STRUCTURAL' instead of 'AUXILIARY', therefore the attribute has to be re-defined within the 'base4kidsPerson' object class, as the entries already contain a structural object class.

[1] https://tools.ietf.org/html/rfc4519#section-2.2
[2] https://tools.ietf.org/html/rfc4519#section-3.2